### PR TITLE
#4 Wiki Editing in tree structure - toggle button

### DIFF
--- a/controllers/OverviewController.php
+++ b/controllers/OverviewController.php
@@ -124,4 +124,16 @@ class OverviewController extends BaseController
 
         return $this->redirect(Url::toOverview($this->contentContainer));
     }
+
+    public function actionToggleWikiTreeEditing()
+    {
+        $module = Yii::$app->getModule('wiki');
+        $user = Yii::$app->user->identity;
+        $editingEnabled = $module->settings->contentContainer($user)->get('wikiTreeEditingEnabled');
+
+        $newState = !$editingEnabled;
+        $module->settings->contentContainer($user)->set('wikiTreeEditingEnabled', $newState);
+
+        return $this->redirect(Url::toOverview($this->contentContainer));
+    }
 }

--- a/messages/de/base.php
+++ b/messages/de/base.php
@@ -92,4 +92,6 @@ return [
     'Enable Default overview numbering for all spaces' => 'Standard-übersichtsnummerierung für alle Bereiche aktivieren',
     'Enable wiki page header numbering for all users by default' => 'Nummerierung der Überschriften standardmäßig für alle Benutzer aktivieren',
     'Enable overview numbering for all users by default' => 'Nummerierung der Seitentitel für alle Benutzer standardmäßig aktivieren',
+    'Disable wiki tree editing' => 'wiki tree Bearbeitung deaktivieren',
+    'Enable wiki tree editing' => 'wiki tree Bearbeitung aktivieren',
 ];

--- a/messages/de/base.php
+++ b/messages/de/base.php
@@ -92,6 +92,6 @@ return [
     'Enable Default overview numbering for all spaces' => 'Standard-übersichtsnummerierung für alle Bereiche aktivieren',
     'Enable wiki page header numbering for all users by default' => 'Nummerierung der Überschriften standardmäßig für alle Benutzer aktivieren',
     'Enable overview numbering for all users by default' => 'Nummerierung der Seitentitel für alle Benutzer standardmäßig aktivieren',
-    'Disable wiki tree editing' => 'wiki tree Bearbeitung deaktivieren',
-    'Enable wiki tree editing' => 'wiki tree Bearbeitung aktivieren',
+    'Disable wiki tree editing' => 'Bearbeitung der Seitenhierachie deaktivieren',
+    'Enable wiki tree editing' => 'Bearbeitung der Seitenhierachie  aktivieren',
 ];

--- a/tests/codeception/functional/WikiTreeEditingButtonCest.php
+++ b/tests/codeception/functional/WikiTreeEditingButtonCest.php
@@ -10,13 +10,12 @@ use humhub\modules\user\models\User;
 use wiki\FunctionalTester;
 use Yii;
 
-class NumberingButtonCest
+class EditingButtonCest
 {
-    public function testNumberingButtonHtml(FunctionalTester $I)
+    public function testEditingButtonHtml(FunctionalTester $I)
     {
         $I->wantTo('check if the wiki tree editing button toggles between enabled and disabled states at overview');
-        $space = $I->loginBySpaceUserGroup(Space::USERGROUP_MEMBER);
-        $I->amAdmin(true);
+        $space = $I->loginBySpaceUserGroup(Space::USERGROUP_ADMIN);
         $I->enableModule($space->guid, 'wiki');
         $category = $I->createWiki($space, 'Test Wiki Page', 'Test Wiki Page content');
         
@@ -24,12 +23,36 @@ class NumberingButtonCest
 
         $I->seeElement('a.toggle-editing');
         $I->see('Enable wiki tree editing', 'a.toggle-editing');
+        $I->dontSeeElement('.drag-icon');
 
         $I->click('a.toggle-editing');
         $I->see('Disable wiki tree editing', 'a.toggle-editing');
+        $I->seeElement('.drag-icon');
 
         $I->click('a.toggle-editing');
         $I->see('Enable wiki tree editing', 'a.toggle-editing');
+        $I->dontSeeElement('.drag-icon');
+    }
 
+    public function testEditingButtonVisibilityForMember(FunctionalTester $I)
+    {
+        $I->wantTo('Check if editing button is not visible for member');
+        $space = $I->loginBySpaceUserGroup(Space::USERGROUP_MEMBER);
+        $I->enableModule($space->guid, 'wiki');
+        $category = $I->createWiki($space, 'Test Wiki Page', 'Test Wiki Page content');
+
+        $I->amOnSpace($space->guid, '/wiki/overview/list-categories');
+        $I->dontSeeElement('a.toggle-editing');
+    }
+
+    public function testEditingButtonVisibilityForModerator(FunctionalTester $I)
+    {
+        $I->wantTo('Check if editing button is visible for moderator');
+        $space = $I->loginBySpaceUserGroup(Space::USERGROUP_MODERATOR);
+        $I->enableModule($space->guid, 'wiki');
+        $category = $I->createWiki($space, 'Test Wiki Page', 'Test Wiki Page content');
+
+        $I->amOnSpace($space->guid, '/wiki/overview/list-categories');
+        $I->seeElement('a.toggle-editing');
     }
 }

--- a/tests/codeception/functional/WikiTreeEditingButtonCest.php
+++ b/tests/codeception/functional/WikiTreeEditingButtonCest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace wiki\functional;
+
+use humhub\modules\space\models\Space;
+use humhub\modules\wiki\helpers\Url;
+use humhub\modules\wiki\models\WikiPage;
+use humhub\modules\wiki\Module;
+use humhub\modules\user\models\User;
+use wiki\FunctionalTester;
+use Yii;
+
+class NumberingButtonCest
+{
+    public function testNumberingButtonHtml(FunctionalTester $I)
+    {
+        $I->wantTo('check if the wiki tree editing button toggles between enabled and disabled states at overview');
+        $space = $I->loginBySpaceUserGroup(Space::USERGROUP_MEMBER);
+        $I->amAdmin(true);
+        $I->enableModule($space->guid, 'wiki');
+        $category = $I->createWiki($space, 'Test Wiki Page', 'Test Wiki Page content');
+        
+        $I->amOnSpace($space->guid, '/wiki/overview/list-categories');
+
+        $I->seeElement('a.toggle-editing');
+        $I->see('Enable wiki tree editing', 'a.toggle-editing');
+
+        $I->click('a.toggle-editing');
+        $I->see('Disable wiki tree editing', 'a.toggle-editing');
+
+        $I->click('a.toggle-editing');
+        $I->see('Enable wiki tree editing', 'a.toggle-editing');
+
+    }
+}

--- a/views/overview/list-categories.php
+++ b/views/overview/list-categories.php
@@ -49,7 +49,8 @@ $settings = new DefaultSettings(['contentContainer' => $contentContainer]);
                     ?>
                     <span class="dropdown">
                         <button type="button" class="btn btn-info btn-sm dropdown-toggle" data-toggle="dropdown" aria-haspopup="true">
-                            <?= Yii::t('WikiModule.base', 'Options') ?>
+                        <i class="fa fa-cog"></i>    
+                        <?= Yii::t('WikiModule.base', 'Options') ?>
                         </button>
                         <ul class="dropdown-menu" aria-labelledby="dropdownMenuButton">
                             <li>

--- a/views/overview/list-categories.php
+++ b/views/overview/list-categories.php
@@ -16,6 +16,7 @@ use humhub\modules\wiki\widgets\CategoryListView;
 use humhub\modules\wiki\widgets\WikiContent;
 use humhub\modules\wiki\widgets\WikiSearchForm;
 use humhub\widgets\Button;
+use humhub\modules\wiki\permissions\AdministerPages;
 
 /* @var $this View */
 /* @var $contentContainer ContentContainerActiveRecord */
@@ -44,10 +45,16 @@ $settings = new DefaultSettings(['contentContainer' => $contentContainer]);
                         $module = Yii::$app->getModule('wiki');    
                         $user = Yii::$app->user->identity;
                         $numberingEnabled = $module->settings->contentContainer($user)->get('overviewNumberingEnabled');
+                        $editingEnabled = $module->settings->contentContainer($user)->get('wikiTreeEditingEnabled', FALSE);
                     ?>
                     <a href="<?= Url::current(['toggle-numbering']) ?>" class="btn btn-info btn-sm toggle-numbering">
                         <?= $numberingEnabled ? Yii::t('WikiModule.base', 'Disable Numbering') : Yii::t('WikiModule.base', 'Enable Numbering') ?>
                     </a>
+                    <?php if ($contentContainer->can(AdministerPages::class)): ?>
+                        <a href="<?= Url::current(['toggle-wiki-tree-editing']) ?>" class="btn btn-info btn-sm toggle-editing">
+                            <?= $editingEnabled ? Yii::t('WikiModule.base', 'Disable wiki tree editing') : Yii::t('WikiModule.base', 'Enable wiki tree editing') ?>
+                        </a>
+                    <?php endif; ?>
                 </div>
                 <div class="clearfix"></div>
             </div>

--- a/views/overview/list-categories.php
+++ b/views/overview/list-categories.php
@@ -47,14 +47,25 @@ $settings = new DefaultSettings(['contentContainer' => $contentContainer]);
                         $numberingEnabled = $module->settings->contentContainer($user)->get('overviewNumberingEnabled');
                         $editingEnabled = $module->settings->contentContainer($user)->get('wikiTreeEditingEnabled', FALSE);
                     ?>
-                    <a href="<?= Url::current(['toggle-numbering']) ?>" class="btn btn-info btn-sm toggle-numbering">
-                        <?= $numberingEnabled ? Yii::t('WikiModule.base', 'Disable Numbering') : Yii::t('WikiModule.base', 'Enable Numbering') ?>
-                    </a>
-                    <?php if ($contentContainer->can(AdministerPages::class)): ?>
-                        <a href="<?= Url::current(['toggle-wiki-tree-editing']) ?>" class="btn btn-info btn-sm toggle-editing">
-                            <?= $editingEnabled ? Yii::t('WikiModule.base', 'Disable wiki tree editing') : Yii::t('WikiModule.base', 'Enable wiki tree editing') ?>
-                        </a>
-                    <?php endif; ?>
+                    <span class="dropdown">
+                        <button type="button" class="btn btn-info btn-sm dropdown-toggle" data-toggle="dropdown" aria-haspopup="true">
+                            <?= Yii::t('WikiModule.base', 'Options') ?>
+                        </button>
+                        <ul class="dropdown-menu" aria-labelledby="dropdownMenuButton">
+                            <li>
+                                <a href="<?= Url::current(['toggle-numbering']) ?>" class="toggle-numbering">
+                                    <?= $numberingEnabled ? Yii::t('WikiModule.base', 'Disable Numbering') : Yii::t('WikiModule.base', 'Enable Numbering') ?>
+                                </a>
+                            </li>
+                            <?php if ($contentContainer->can(AdministerPages::class)): ?>
+                                <li>
+                                <a href="<?= Url::current(['toggle-wiki-tree-editing']) ?>" class="toggle-editing">
+                                    <?= $editingEnabled ? Yii::t('WikiModule.base', 'Disable wiki tree editing') : Yii::t('WikiModule.base', 'Enable wiki tree editing') ?>
+                                </a>
+                                </li>
+                            <?php endif; ?>
+                        </ul>
+                    </span>
                 </div>
                 <div class="clearfix"></div>
             </div>

--- a/widgets/PageListItemTitle.php
+++ b/widgets/PageListItemTitle.php
@@ -90,14 +90,11 @@ class PageListItemTitle extends Widget
             $this->titleInfo = Yii::t('WikiModule.base', '({n,plural,=1{+1 subpage}other{+{count} subpages}})', ['n' => $this->page->childrenCount, 'count' => $this->page->childrenCount]);
         }
 
-        // Get the current module
         $module = Yii::$app->getModule('wiki');        
-        // Get the current user
         $user = Yii::$app->user->identity;
-        // Retrieve the current numbering state for this user from the settings
         $numberingEnabled = $module->settings->contentContainer($user)->get('overviewNumberingEnabled');
+        $editingEnabled = $module->settings->contentContainer($user)->get('wikiTreeEditingEnabled', FALSE);
         
-        // Generate numbering for categories and pages
         return $this->render('pageListItemTitle', [
             'page' => $this->page,
             'title' => $numberingEnabled ? ($this->generateNumbering($this->level) . ' ' . $this->title) : $this->title,
@@ -105,7 +102,7 @@ class PageListItemTitle extends Widget
             'titleInfo' => $this->titleInfo,
             'url' => $this->page ? $this->page->getUrl() : null,
             'icon' => $this->icon ?? $icon,
-            'showDrag' => $this->showDrag,
+            'showDrag' => $this->showDrag and $editingEnabled,
             'showAddPage' => $this->showAddPage,
             'options' => $this->getOptions(),
             'level' => $this->level,


### PR DESCRIPTION
Hello @marius-meissner,
TO solve the issue #4, A toggle button has been implemented in order to toggle between enabling and disabling editing the wiki tree structure. The code is ready for review.