### PR TITLE
#17 made is_appendable attribute to be null

### DIFF
--- a/migrations/m250714_215201_alter_is_appendable_nullable.php
+++ b/migrations/m250714_215201_alter_is_appendable_nullable.php
@@ -1,0 +1,25 @@
+<?php
+
+use yii\db\Migration;
+
+/**
+ * Class m250714_215201_alter_is_appendable_nullable
+ */
+class m250714_215201_alter_is_appendable_nullable extends Migration
+{   
+    /**
+     * {@inheritdoc}
+     */
+    public function safeUp()
+    {
+        $this->alterColumn('wiki_page', 'is_appendable', $this->boolean()->null()->defaultValue(false));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function safeDown()
+    {
+        $this->alterColumn('wiki_page', 'is_appendable', $this->boolean()->notNull()->defaultValue(false));
+    }
+}


### PR DESCRIPTION
Certain permissions didnt allow the member to access the code part where i had forced the is_appendable to be 0 as default. I just made the is_appendable to be a defualt null value, now the members shouldnt have nay issues. The moderators and admin can also user the template system as before without needing any change to it.