### PR TITLE
#19 editing conflict modal for append

### DIFF
--- a/resources/js/humhub.wiki.Form.js
+++ b/resources/js/humhub.wiki.Form.js
@@ -459,8 +459,8 @@ humhub.module('wiki.Form', function(module, require, $) {
     }
 
     function pollEditingStatus() {
-        const $container = $('[data-url-editing-status]');
-        const url = $container.data('url-editing-status');
+        const $container = $('[data-append-url-editing-status]');
+        const url = $container.data('append-url-editing-status');
         if (!url) return;
         client.get(url).then(function (response) {
             if (response.success && response.isEditing) {

--- a/views/page/append.php
+++ b/views/page/append.php
@@ -32,7 +32,7 @@ Assets::register($this);
                     'data-ui-init' => '1'],
                 ]); ?>
         
-        <div id="append-editor" data-url-editing-status="<?= Html::encode(Url::toWikiEditingStatus($appendForm->page)) ?>" data-url-append-content = <?=Url::toWikiGetAppendContent($appendForm->page);?> >
+        <div id="append-editor" data-append-url-editing-status="<?= Html::encode(Url::toWikiEditingStatus($appendForm->page)) ?>" data-url-append-content = <?=Url::toWikiGetAppendContent($appendForm->page);?> >
             <?= $form->field($appendForm->page, 'title')
                         ->textInput([
                             'disabled' => true,


### PR DESCRIPTION
A modal that was intended for wiki page edit was getting called in the append editor, due to conflicting naming in a div class containing the URL for editing status. Just changed the name and the issue was resolved.